### PR TITLE
Only copy gzip ssec files

### DIFF
--- a/bin/viirs_awips.rb
+++ b/bin/viirs_awips.rb
@@ -27,7 +27,7 @@ class SnppAwipsClamp <  ProcessingFramework::CommandLineHelper
       Dir.glob('SSEC_AWIPS*') do |awips_file|
         gzip!(awips_file)
       end
-      copy_output(output, '*')#processing_cfg['save'])
+      copy_output(output, 'SSEC_AWIPS*.gz')#processing_cfg['save'])
     end
   end
 end


### PR DESCRIPTION
@spruceboy @teknofire    

Quick hotfix to limit what viirs awips files are copied to the cache. 