### PR TITLE
Hotfix METOP scripts working dir

### DIFF
--- a/bin/metop_l0.rb
+++ b/bin/metop_l0.rb
@@ -16,7 +16,8 @@ class MetopL0Clamp < ProcessingFramework::CommandLineHelper
 
   def execute
     exit_with_error("File size to small", 11) if File.stat(input).size < 25000000
-
+    
+    basename = File.basename(input) unless basename
     working_dir = "#{tempdir}/#{basename}"
 
     inside(working_dir) do

--- a/bin/metop_l1.rb
+++ b/bin/metop_l1.rb
@@ -15,6 +15,8 @@ class MetopL0Clamp <  ProcessingFramework::CommandLineHelper
   parameter "OUTPUT", 'The output directory'
 
   def execute
+
+    basename = File.basename(input) unless basename
     @working_dir = "#{tempdir}/#{basename}"
 
     inside(@working_dir) do


### PR DESCRIPTION
The scripts workdir *must* be created as a sub-directory of the sidekiq workdir.
If it isn't, the scripts remove their cwd and error.

@spruceboy @teknofire 