### PR TITLE
Reset dayfaction to default.

### DIFF
--- a/config/viirs_awips.yml
+++ b/config/viirs_awips.yml
@@ -3,7 +3,7 @@ driver_crefl: crefl2awips.sh
 configs:
   default:
    options: "--grid-coverage 0"
-   day_cover: "70"
+   day_cover: "0.10"
    grid: 203
    save: 
      - "UAF_AWIPS_npp_viirs_adaptive*"


### PR DESCRIPTION
This sets the --day-fraction argument back to the default.   I set it wrong, and while it makes the fog products show up, the reflectance bands all go away because the threadhold is all wrong.  

My error.  

Signed-off-by: JC <jay@alaska.edu>