### PR TITLE
Not saving the "cal" file.

### DIFF
--- a/bin/modis_tdf.rb
+++ b/bin/modis_tdf.rb
@@ -76,7 +76,8 @@ class ModisTdfClamp <  ProcessingFramework::CommandLineHelper
       terascan_run(command)
     end
 
-    FileUtils.mv(tdf + '.bt.tdf', basename + '.modis_cal.tdf')
+    FileUtils.mv(tdf + '.bt.tdf', basename + '.modis_bright.tdf')
+    FileUtils.mv(tdf + '.bt', basename + '.modis_cal.tdf')
   end
 
   # does night conversion - no 250k or 500k


### PR DESCRIPTION
I missed this the first round - it was saving only one of the two files, and had the names mixed up wrong.  
USGS should be querried as to if they are using both. 
Signed-off-by: JC jay@alaska.edu

@smacfarlane - this change is needed before feeding the usgs. 
