### PR TITLE
Initial hsrtv support.

### DIFF
--- a/bin/cris_hsrtv.rb
+++ b/bin/cris_hsrtv.rb
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+# Cris l2 processing tool..
+# Run like:
+# cris_hsrtv.rb -t /hub/raid/jcable/cris/test_data/tmp /hub/raid/jcable/cris/test_data/npp.17011.1305/ /hub/raid/jcable/cris/test_data/out/npp.17011.1306
+
+ENV['BUNDLE_GEMFILE'] = File.join(File.expand_path('../..', __FILE__), 'Gemfile')
+require 'bundler/setup'
+require 'fileutils'
+require_relative '../lib/processing_framework'
+
+class CrisHsrtvClamp <  ProcessingFramework::CommandLineHelper
+  default_config 'cris_hsrtv'
+  banner 'This tool does HSRTV processing for CrIS.'
+
+  parameter 'INPUT', 'Input directory'
+  parameter 'OUTPUT', 'Output directory'
+
+  def execute
+    basename = File.basename(input) unless basename
+
+    working_dir = "#{tempdir}/#{basename}"
+    inside(working_dir) do
+      command = " #{conf['driver']} #{conf['options']} #{input}"
+      result = shell_out!(command)
+    end
+
+    Dir.glob(conf['save']).each do |hsrtv_glob|
+      copy_output(output, hsrtv_glob)
+    end
+  end
+end
+
+CrisHsrtvClamp.run

--- a/config/cris_hsrtv.yml
+++ b/config/cris_hsrtv.yml
@@ -1,0 +1,4 @@
+driver: run_HSRTV.scr
+options: " 3 "
+save:
+  - "CrIS*atm_prof_rtv.h5"


### PR DESCRIPTION
adds basic hsrtv support.  Level 2 processing for cris

requires the CSPP UW HSRTV package from SSEC. 

Details here:
ftp://ftp.ssec.wisc.edu/pub/CSPP/hidden/CrIS/EDR/hsrtv/v1.3/CSPP_UW_HSRTV_V1.3_README.txt

packages here:
ftp://ftp.ssec.wisc.edu/pub/CSPP/hidden/CrIS/EDR/hsrtv/v1.3/CSPP_UW_HSRTV_V1.3.tar.gz
ftp://ftp.ssec.wisc.edu/pub/CSPP/hidden/CrIS/EDR/hsrtv/v1.3/CSPP_UW_HSRTV_coeffs_v1.2.tar.gz

the "CSPP_UW_HSRTV/env/uw_hs_l2.bash_env. sh" script needs modified to point at the correct location, or another similar script made with the correct location. 

Signed-off-by: JC <jc@alaska.edu>