### PR TITLE
Sport mods

### DIFF
--- a/bin/sport_slice.rb
+++ b/bin/sport_slice.rb
@@ -6,7 +6,7 @@ require_relative '../lib/processing_framework'
 
 class SportSliceClamp <  ProcessingFramework::CommandLineHelper
   banner 'This tool makes geotifs from modis and viirs data .'
-  default_config 'p2g_geotif'
+  default_config 'sport_slice'
 
   option ['-m', '--mode'], 'mode', 'The mode to use.',  required: true
   option ['-p', '--processors'], 'processors', 'The number of processors to use for processing.',  environment_variable: 'PROCESSING_NUMBER_OF_CPUS', default: 1

--- a/bin/sport_slice.rb
+++ b/bin/sport_slice.rb
@@ -49,4 +49,4 @@ class SportSliceClamp <  ProcessingFramework::CommandLineHelper
   end
 end
 
-SportSliceCamp.run
+SportSliceClamp.run

--- a/bin/sport_slice.rb
+++ b/bin/sport_slice.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+ENV['BUNDLE_GEMFILE'] = File.join(File.expand_path('../..', __FILE__), 'Gemfile')
+require 'bundler/setup'
+require 'fileutils'
+require_relative '../lib/processing_framework'
+
+class SportSliceClamp <  ProcessingFramework::CommandLineHelper
+  banner 'This tool makes geotifs from modis and viirs data .'
+  default_config 'p2g_geotif'
+
+  option ['-m', '--mode'], 'mode', 'The mode to use.',  required: true
+  option ['-p', '--processors'], 'processors', 'The number of processors to use for processing.',  environment_variable: 'PROCESSING_NUMBER_OF_CPUS', default: 1
+
+  parameter 'INPUT', 'The input directory'
+  parameter 'OUTPUT', 'The output directory'
+
+  def execute
+    exit_with_error("Unknown/unconfigured mode #{mode}", 19) unless conf['configs'][mode]
+    processing_cfg = conf['configs'][mode]
+
+    basename = File.basename(input) unless basename
+    working_dir = "#{tempdir}/#{basename}"
+
+    inside(working_dir) do
+      # if grid is defined in config, use it
+      grid = ''
+      if processing_cfg['grid']
+        grid = " --grid-configs #{get_grid_path(processing_cfg)} "
+      end
+
+      # do each task
+      processing_cfg['tasks'].each do |task|
+        shell_out("#{task} #{grid} -d #{input}")
+      end
+
+      # compress output
+      Dir.glob(processing_cfg['save']).each do |awips_file|
+        gzip!(awips_file)
+      end
+
+      # copy output
+      copy_output(output, processing_cfg['save'])
+    end
+  end
+
+  # gets path to the grid file.
+  def get_grid_path(cfg)
+    File.join(File.expand_path('../../config', __FILE__), cfg['grid_file'])
+  end
+end
+
+SportSliceCamp.run

--- a/config/sport_slice.yml
+++ b/config/sport_slice.yml
@@ -1,0 +1,17 @@
+configs:
+  viirs:
+    compress: "gzip"
+    tasks:
+     - "viirs2binary.sh -p 'm07 m12 m14 m15 m16 m_sat_zenith_angle m_solar_zenith_angle' --dtype real4 --grid-coverage=0.01 -g 203 --output-pattern {satellite}_{instrument}_{product_name}_{begin_time}_{grid_name}.bin"
+    save:
+     - "*.bin"
+     - "*.bin.gz"
+  modis:
+    compress: "gzip"
+    tasks:
+     - "modis2binary.sh -p vis02 bt20 bt29 bt31 bt32 satellite_zenith_angle solar_zenith_angle --dtype real4 --grid-coverage=0.01 -g 203 --output-pattern {satellite}_{instrument}_{product_name}_{begin_time}_{grid_name}.bin"
+    save:
+     - "*.bin"
+     - "*.bin.gz"
+limits:
+  processor: 1


### PR DESCRIPTION
This makes the binary slices of data that sport plans to use.  It needs to happen after the l1 processing (seadas for modis, and sdr for viirs), and makes *bin.gz files.  

Options are simple,
-m viirs for npp, -m modis for aqua & terra . 

Needs polar2grid, but can use a "small" polar2grid if needed, as it is very quick to run. 

This will get us out of hosting a vm for sport, as these slices are very small, and they can fetch them quickly from our processing stack, make their products, and push them into LDM. 

 @teknofire let me know if you would like any changes. 