### PR TITLE
clean env option for shell_out

### DIFF
--- a/lib/processing_framework/shell_out_helper.rb
+++ b/lib/processing_framework/shell_out_helper.rb
@@ -1,4 +1,5 @@
 require 'mixlib/shellout'
+require 'shellwords'
 
 module ProcessingFramework
   module ShellOutHelper
@@ -8,7 +9,7 @@ module ProcessingFramework
     # runs command with `env -i` if :clean_environment is passed as option
     def shell_out(command, opts = {})
       if opts[:clean_environment].delete do
-        command = "env -i bash -l -c '"+ command+"''"
+        command = "env -i bash -l -c #{command.shellescape}"
       end
       opts = SHELL_OUT_DEFAULTS.merge(opts)
       cmd = ::Mixlib::ShellOut.new(command, opts)

--- a/lib/processing_framework/shell_out_helper.rb
+++ b/lib/processing_framework/shell_out_helper.rb
@@ -5,7 +5,11 @@ module ProcessingFramework
     SHELL_OUT_DEFAULTS = { live_stream: STDOUT, timeout: 60 * 60 }
 
     # runs command, with opts
+    # runs command with `env -i` if :clean_env is passed as option
     def shell_out(command, opts = {})
+      if opts[:clean_env].delete do
+        command = "env -i "+ command
+      end
       opts = SHELL_OUT_DEFAULTS.merge(opts)
       cmd = ::Mixlib::ShellOut.new(command, opts)
       cmd.run_command

--- a/lib/processing_framework/shell_out_helper.rb
+++ b/lib/processing_framework/shell_out_helper.rb
@@ -5,10 +5,10 @@ module ProcessingFramework
     SHELL_OUT_DEFAULTS = { live_stream: STDOUT, timeout: 60 * 60 }
 
     # runs command, with opts
-    # runs command with `env -i` if :clean_env is passed as option
+    # runs command with `env -i` if :clean_environment is passed as option
     def shell_out(command, opts = {})
-      if opts[:clean_env].delete do
-        command = "env -i "+ command
+      if opts[:clean_environment].delete do
+        command = "env -i bash -l -c '"+ command+"''"
       end
       opts = SHELL_OUT_DEFAULTS.merge(opts)
       cmd = ::Mixlib::ShellOut.new(command, opts)


### PR DESCRIPTION
This is not tested but a proposal for how we can fix this by passing in an option like :clean_env

This likely would not work correctly since it would be tricky to pass a  ruby symbol yet but hopefully gives us a start for discussion on a potential fix.
