### PR TITLE
fix for dbrtn python2 requirement

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -71,7 +71,7 @@ if [[ -f \$TSCANROOT/etc/tscan.bash_profile ]]; then
 fi
 
 if [ `basename ${1}` = dbrtn_notify_gina_alaska.sh ]; then
-  export PATH=/usr/bin/:/usr/local/bin:$PATH
+  export PATH=/usr/bin/:/usr/local/bin:\$PATH
 fi
 
 

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -70,6 +70,10 @@ if [[ -f \$TSCANROOT/etc/tscan.bash_profile ]]; then
   source \$TSCANROOT/etc/tscan.bash_profile
 fi
 
+if [ `basename ${1}` = dbrtn_notify_gina_alaska.sh ]; then
+  export PATH=/usr/bin/:/usr/local/bin:$PATH
+fi
+
 
 exec ${1}.real \$@
 EOF


### PR DESCRIPTION
hack hack -- idea
```
hab studio enter
build
exit
hab pkg install results/uafgina-sandy-tuils-(blahblah)
cd $(hab pkg path uafgina/sandy-utils)
cd bin
 DBRTN_UAFGINA_APISECRET=(find in that one spot) DBRTN_UAFGINA_APIKEY=(find in that one spot)  ./dbrtn_notify_gina_alaska.sh \
  -s uafgina -d terra:modis:64 20170815 203700 \
  http://nrt-dds-prod.gina.alaska.edu/uafgina/terra/level0/2017/08/t1.17228.2037/P0420064AAAAAAAAAAAAAA17228205047000.PDS 
```
results in successful run:
```
Wed Aug 16 21:59:30 UTC 2017 [DbRtn ERROR] Dryrun Succeeded!
Form parameters validated
Successfully downloaded http://nrt-dds-prod.gina.alaska.edu/uafgina/terra/level0/2017/08/t1.17228.2037/P0420064AAAAAAAAAAAAAA17228205047000.PDS
Total time: 0.20 seconds
````
